### PR TITLE
Updated Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install pre-commit globally
 
 Clone the repository
 
-    git clone git@github.com:SuperDoxin/Butter-Chat.git
+    git clone https://github.com/SuperDoxin/Butter-Chat.git
 
 Change into the repository folder
 


### PR DESCRIPTION
I changed the command to git clone the repo because `git clone git@github.com:SuperDoxin/Butter-Chat.git` gave me an error while `git clone https://github.com/SuperDoxin/Butter-Chat.git` did not.